### PR TITLE
I've made a change to ensure the `AuthContext` object is also exporte…

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 // import apiClient from '../api/axios';
 import { loginUser } from '../api/authApi'; // Import loginUser
 
-const AuthContext = createContext(null);
+export const AuthContext = createContext(null); // Added export
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null); // Should store { _id, name, email, role, isApproved }


### PR DESCRIPTION
…d directly.

This should address the persistent "Uncaught SyntaxError: The requested module '/src/context/AuthContext.jsx' does not provide an export named 'AuthContext'".

While components like `AdminUserManagementPage` were updated to use the `useAuth` hook, this change ensures that `AuthContext` itself is also available as a named export from `AuthContext.jsx`.

- I modified `AuthContext.jsx` to change `const AuthContext = createContext(null);` to `export const AuthContext = createContext(null);`.
- I verified that `AdminUserManagementPage.jsx` and other key components continue to primarily use the `useAuth` hook.

This provides a fallback if any part of the import chain still attempts to access `AuthContext` directly by name, aiming to resolve the persistent error.