### PR TITLE
fix: Ensure isApproved status is sent in login response

### DIFF
--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -88,6 +88,7 @@ router.post('/login', async (req, res) => {
         name: user.name,
         email: user.email,
         role: user.role,
+        isApproved: user.isApproved, // Added isApproved field
       },
     });
   } catch (error) {


### PR DESCRIPTION
Resolves an issue where admin users (and other pre-approved users) were incorrectly identified as 'Account not approved' by the frontend after login.

The backend POST /api/auth/login route was correctly checking your isApproved status from the database but was omitting this field from the user object returned to the frontend.

This commit modifies backend/routes/authRoutes.js to include `isApproved: user.isApproved` in the user object within the JSON response. This allows the frontend AuthContext to receive and correctly process your approval status.