### PR TITLE
fix: Correct API URL prefixes in adminApi.js

### DIFF
--- a/frontend/src/api/adminApi.js
+++ b/frontend/src/api/adminApi.js
@@ -2,120 +2,122 @@ import axiosInstance from './axios';
 
 export const getUsers = async () => {
   try {
-    const response = await axiosInstance.get('/api/admin/users');
+    const response = await axiosInstance.get('/admin/users'); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response.data;
+    // Standardized error throwing
+    throw error.response?.data || { message: error.message || 'Failed to fetch users' };
   }
 };
 
 // Content Management API functions
 export const createContent = async (moduleId, contentData) => {
   try {
-    const response = await axiosInstance.post(`/api/admin/modules/${moduleId}/content`, contentData);
+    const response = await axiosInstance.post(`/admin/modules/${moduleId}/content`, contentData); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to create content' };
   }
 };
 
 export const updateContent = async (contentId, contentData) => {
   try {
-    const response = await axiosInstance.put(`/api/admin/content/${contentId}`, contentData);
+    const response = await axiosInstance.put(`/admin/content/${contentId}`, contentData); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to update content' };
   }
 };
 
 export const deleteContent = async (contentId) => {
   try {
-    const response = await axiosInstance.delete(`/api/admin/content/${contentId}`);
+    const response = await axiosInstance.delete(`/admin/content/${contentId}`); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to delete content' };
   }
 };
 
 // Module Management API functions
 export const createModule = async (courseId, moduleData) => {
   try {
-    const response = await axiosInstance.post(`/api/admin/courses/${courseId}/modules`, moduleData);
+    const response = await axiosInstance.post(`/admin/courses/${courseId}/modules`, moduleData); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to create module' };
   }
 };
 
 export const updateModule = async (moduleId, moduleData) => {
   try {
-    const response = await axiosInstance.put(`/api/admin/modules/${moduleId}`, moduleData);
+    const response = await axiosInstance.put(`/admin/modules/${moduleId}`, moduleData); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to update module' };
   }
 };
 
 export const deleteModule = async (moduleId) => {
   try {
-    const response = await axiosInstance.delete(`/api/admin/modules/${moduleId}`);
+    const response = await axiosInstance.delete(`/admin/modules/${moduleId}`); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to delete module' };
   }
 };
 
 // Course Management API functions
 export const getCourses = async () => {
   try {
-    const response = await axiosInstance.get('/api/admin/courses');
+    const response = await axiosInstance.get('/admin/courses'); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to fetch courses' };
   }
 };
 
 export const getCourseDetails = async (courseId) => {
   try {
-    const response = await axiosInstance.get(`/api/admin/courses/${courseId}`);
+    const response = await axiosInstance.get(`/admin/courses/${courseId}`); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to fetch course details' };
   }
 };
 
 export const createCourse = async (courseData) => {
   try {
-    const response = await axiosInstance.post('/api/admin/courses', courseData);
+    const response = await axiosInstance.post('/admin/courses', courseData); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to create course' };
   }
 };
 
 export const updateCourse = async (courseId, courseData) => {
   try {
-    const response = await axiosInstance.put(`/api/admin/courses/${courseId}`, courseData);
+    const response = await axiosInstance.put(`/admin/courses/${courseId}`, courseData); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to update course' };
   }
 };
 
 export const deleteCourse = async (courseId) => {
   try {
-    const response = await axiosInstance.delete(`/api/admin/courses/${courseId}`);
+    const response = await axiosInstance.delete(`/admin/courses/${courseId}`); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response?.data || { message: error.message };
+    throw error.response?.data || { message: error.message || 'Failed to delete course' };
   }
 };
 
 export const approveUser = async (userId) => {
   try {
-    const response = await axiosInstance.patch(`/api/admin/users/${userId}/approve`);
+    const response = await axiosInstance.patch(`/admin/users/${userId}/approve`); // Removed /api prefix
     return response.data;
   } catch (error) {
-    throw error.response.data;
+    // Standardized error throwing
+    throw error.response?.data || { message: error.message || 'Failed to approve user' };
   }
 };


### PR DESCRIPTION
Resolves data fetching errors in Admin User Management and Admin Course Management sections.

The API functions in `frontend/src/api/adminApi.js` for fetching users, courses, and managing modules/content were incorrectly prefixing their request URLs with `/api`. Given that the `axiosInstance.baseURL` already includes `/api` (e.g., `http://localhost:5000/api`), this resulted in malformed URLs (e.g., `http://localhost:5000/api/api/admin/users`).

This commit removes the redundant `/api` prefix from all relevant paths in `adminApi.js`, ensuring correct endpoint targeting. For example, calls are now made to `/admin/users` instead of `/api/admin/users` relative to the baseURL.

Error handling in these functions was also standardized. Logout functionality was reviewed and confirmed to be working as expected with no changes needed.