### PR TITLE
Add video ID and content fields to lesson form

### DIFF
--- a/jules-scratch/verification/verify_lesson_form.py
+++ b/jules-scratch/verification/verify_lesson_form.py
@@ -1,0 +1,51 @@
+import asyncio
+from playwright.async_api import async_playwright, expect
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+
+        try:
+            # Step 1: Log in as admin
+            await page.goto("http://localhost:5173/login")
+            await page.get_by_label("Email Address").fill("admin@test.com")
+            await page.get_by_label("Password").fill("password")
+            await page.get_by_role("button", name="Login").click()
+            await expect(page.get_by_text("Admin Dashboard")).to_be_visible()
+
+            # Step 2: Navigate to the courses tab and then to a course
+            await page.get_by_role("button", name="Courses").click()
+            # Click the first course in the list to view details
+            await page.get_by_role("row").nth(1).get_by_role("link").first.click()
+            await expect(page.get_by_text("Course Content")).to_be_visible()
+
+            # Step 3: Open the lesson form
+            # Click to expand the first module's lessons
+            await page.get_by_role("button", name=/Lessons for/).click()
+            # Click "Add Lesson"
+            await page.get_by_role("button", name="Add Lesson").click()
+            await expect(page.get_by_text("Create New Lesson")).to_be_visible()
+
+            # Step 4: Verify conditional field for "video" type
+            await page.get_by_label("Type").select_option("video")
+            await expect(page.get_by_label("YouTube Video ID")).to_be_visible()
+            await expect(page.get_by_label("Content")).not_to_be_visible()
+
+            # Step 5: Verify conditional field for "text" type
+            await page.get_by_label("Type").select_option("text")
+            await expect(page.get_by_label("YouTube Video ID")).not_to_be_visible()
+            await expect(page.get_by_label("Content")).to_be_visible()
+
+            # Step 6: Take a screenshot
+            await page.screenshot(path="jules-scratch/verification/verification.png")
+
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            await page.screenshot(path="jules-scratch/verification/error.png")
+
+        finally:
+            await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/components/LessonForm.tsx
+++ b/src/components/LessonForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormRegister, FieldErrors } from 'react-hook-form';
+import { UseFormRegister, FieldErrors, UseFormWatch } from 'react-hook-form';
 
 interface LessonFormProps {
   onSubmit: (e: React.BaseSyntheticEvent) => void;
@@ -7,9 +7,12 @@ interface LessonFormProps {
   register: UseFormRegister<any>;
   errors: FieldErrors;
   isEditing: boolean;
+  watch: UseFormWatch<any>;
 }
 
-const LessonForm: React.FC<LessonFormProps> = ({ onSubmit, onCancel, register, errors, isEditing }) => {
+const LessonForm: React.FC<LessonFormProps> = ({ onSubmit, onCancel, register, errors, isEditing, watch }) => {
+  const lessonType = watch('type', 'video');
+
   return (
     <div className="bg-gray-50 rounded-lg shadow-inner p-6 my-4">
       <h4 className="text-lg font-semibold text-gray-800 mb-4">
@@ -68,6 +71,38 @@ const LessonForm: React.FC<LessonFormProps> = ({ onSubmit, onCancel, register, e
             {errors.duration && <p className="text-sm text-red-600 mt-1">{errors.duration.message as string}</p>}
           </div>
         </div>
+
+        {lessonType === 'video' && (
+          <div>
+            <label htmlFor="youtubeVideoId" className="block text-sm font-medium text-gray-700">
+              YouTube Video ID
+            </label>
+            <input
+              id="youtubeVideoId"
+              {...register('youtubeVideoId', { required: 'YouTube Video ID is required' })}
+              className="w-full px-3 py-2 mt-1 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+              placeholder="e.g., dQw4w9WgXcQ"
+            />
+            {errors.youtubeVideoId && <p className="text-sm text-red-600 mt-1">{errors.youtubeVideoId.message as string}</p>}
+          </div>
+        )}
+
+        {lessonType === 'text' && (
+          <div>
+            <label htmlFor="content" className="block text-sm font-medium text-gray-700">
+              Content
+            </label>
+            <textarea
+              id="content"
+              {...register('content', { required: 'Content is required for text lessons' })}
+              rows={5}
+              className="w-full px-3 py-2 mt-1 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+              placeholder="Enter lesson content here. HTML is supported."
+            />
+            {errors.content && <p className="text-sm text-red-600 mt-1">{errors.content.message as string}</p>}
+          </div>
+        )}
+
         <div className="flex justify-end space-x-4">
           <button
             type="button"

--- a/src/components/LessonManagement.tsx
+++ b/src/components/LessonManagement.tsx
@@ -12,6 +12,8 @@ interface Lesson {
   title: string;
   description: string;
   type: 'video' | 'text';
+  content?: string;
+  youtubeVideoId?: string;
   duration: number;
   order: number;
 }
@@ -26,7 +28,7 @@ const LessonManagement: React.FC<LessonManagementProps> = ({ moduleId, lessons, 
   const [showLessonForm, setShowLessonForm] = useState(false);
   const [editingLesson, setEditingLesson] = useState<Lesson | null>(null);
 
-  const { register, handleSubmit, reset, setValue, formState: { errors } } = useForm<Lesson>();
+  const { register, handleSubmit, reset, setValue, watch, formState: { errors } } = useForm<Lesson>();
 
   const handleEdit = (lesson: Lesson) => {
     setEditingLesson(lesson);
@@ -34,6 +36,8 @@ const LessonManagement: React.FC<LessonManagementProps> = ({ moduleId, lessons, 
     setValue('description', lesson.description);
     setValue('type', lesson.type);
     setValue('duration', lesson.duration);
+    setValue('content', lesson.content);
+    setValue('youtubeVideoId', lesson.youtubeVideoId);
     setShowLessonForm(true);
   };
 
@@ -97,6 +101,7 @@ const LessonManagement: React.FC<LessonManagementProps> = ({ moduleId, lessons, 
           register={register}
           errors={errors}
           isEditing={!!editingLesson}
+          watch={watch}
         />
       )}
 


### PR DESCRIPTION
This commit addresses an issue where administrators could not add a YouTube video ID or content to a lesson because the input fields were missing from the lesson creation form.

The following changes have been made:
- Modified `src/components/LessonForm.tsx` to conditionally display an input field for the "YouTube Video ID" when the lesson type is set to "video".
- Added a `textarea` for "Content" when the lesson type is set to "text" to ensure text-based lessons can be created.
- Updated `src/components/LessonManagement.tsx` to pass the necessary `watch` function to the form and to handle setting the values for the new fields when editing a lesson.

This change ensures that administrators can now create both video and text-based lessons with the appropriate content.